### PR TITLE
feat: add Partial keyword fluent API for partial classes

### DIFF
--- a/EasyCodeBuilder.Test/Csharp/PartialKeywordTests.cs
+++ b/EasyCodeBuilder.Test/Csharp/PartialKeywordTests.cs
@@ -1,0 +1,140 @@
+using Fengb3.EasyCodeBuilder.Csharp;
+using Fengb3.EasyCodeBuilder.Csharp.OptionConfigurations;
+using Xunit.Abstractions;
+
+namespace EasyCodeBuilder.Test.Csharp;
+
+public class PartialKeywordTests(ITestOutputHelper testOutputHelper)
+{
+    private static string Normalize(string text) => text.Replace("\r\n", "\n").Trim();
+
+    [Fact]
+    public void TestPartialClassInNamespace()
+    {
+        var @namespace = new NamespaceOption()
+            .WithName("MyNamespace")
+            .Partial.Class(cls =>
+            {
+                cls.WithName("MyClass");
+            });
+
+        var code = @namespace.Build();
+
+        const string expected =
+            """
+            namespace MyNamespace
+            {
+              partial class MyClass
+              {
+              }
+            }
+            """;
+
+        Assert.Equal(Normalize(expected), Normalize(code));
+        testOutputHelper.WriteLine(code);
+    }
+
+    [Fact]
+    public void TestPublicPartialClass()
+    {
+        var @namespace = new NamespaceOption()
+            .WithName("MyNamespace")
+            .Public.Partial.Class(cls =>
+            {
+                cls.WithName("MyClass");
+            });
+
+        var code = @namespace.Build();
+
+        const string expected =
+            """
+            namespace MyNamespace
+            {
+              public partial class MyClass
+              {
+              }
+            }
+            """;
+
+        Assert.Equal(Normalize(expected), Normalize(code));
+        testOutputHelper.WriteLine(code);
+    }
+
+    [Fact]
+    public void TestPublicStaticPartialClass()
+    {
+        var @namespace = new NamespaceOption()
+            .WithName("MyNamespace")
+            .Public.Static.Partial.Class(cls =>
+            {
+                cls.WithName("MyClass");
+            });
+
+        var code = @namespace.Build();
+
+        const string expected =
+            """
+            namespace MyNamespace
+            {
+              public static partial class MyClass
+              {
+              }
+            }
+            """;
+
+        Assert.Equal(Normalize(expected), Normalize(code));
+        testOutputHelper.WriteLine(code);
+    }
+
+    [Fact]
+    public void TestPartialNestedClass()
+    {
+        var code = new TypeOption()
+            .WithTypeKind(TypeOption.Type.Class)
+            .WithName("OuterClass")
+            .WithKeywords("public")
+            .Partial.NestedClass(nc => nc
+                .WithName("InnerClass")
+            )
+            .Build();
+
+        const string expected =
+            """
+            public class OuterClass
+            {
+              partial class InnerClass
+              {
+              }
+            }
+            """;
+
+        Assert.Equal(Normalize(expected), Normalize(code));
+        testOutputHelper.WriteLine(code);
+    }
+
+    [Fact]
+    public void TestPublicPartialNestedClass()
+    {
+        var code = new TypeOption()
+            .WithTypeKind(TypeOption.Type.Class)
+            .WithName("OuterClass")
+            .WithKeywords("public")
+            .Public.Partial.NestedClass(nc => nc
+                .WithName("InnerClass")
+            )
+            .Build();
+
+        const string expected =
+            """
+            public class OuterClass
+            {
+              public partial class InnerClass
+              {
+              }
+            }
+            """;
+
+        Assert.Equal(Normalize(expected), Normalize(code));
+        testOutputHelper.WriteLine(code);
+    }
+}

--- a/EasyCodeBuilder/Csharp/NamespaceOption.cs
+++ b/EasyCodeBuilder/Csharp/NamespaceOption.cs
@@ -42,6 +42,11 @@ public class NamespaceOption : CodeOption
     /// 私有访问修饰符配置器
     /// </summary>
     public KeywordOptionConfigurator<NamespaceOption> Private => Has.Private;
+
+    /// <summary>
+    /// partial 修饰符配置器
+    /// </summary>
+    public KeywordOptionConfigurator<NamespaceOption> Partial => Has.Partial;
 }
 
 /// <summary>

--- a/EasyCodeBuilder/Csharp/OptionConfigurations/OptionConfigurations.cs
+++ b/EasyCodeBuilder/Csharp/OptionConfigurations/OptionConfigurations.cs
@@ -132,6 +132,48 @@ public static class KeywordConfiguratorExtensions
 
     #endregion
 
+    #region Add nested type to type
+
+    /// <summary>
+    /// 添加嵌套类
+    /// </summary>
+    /// <param name="configurator">关键字配置器</param>
+    /// <param name="configure">嵌套类选项配置委托</param>
+    /// <returns>类型选项</returns>
+    public static TypeOption NestedClass(
+        this KeywordOptionConfigurator<TypeOption> configurator,
+        Func<TypeOption, TypeOption> configure
+    )
+    {
+        configurator.Parent.AddChild<TypeOption, TypeOption>(to =>
+        {
+            configurator.Configure(keyword => to.WithKeyword(keyword));
+            configure(to);
+        });
+        return configurator.Parent;
+    }
+
+    /// <summary>
+    /// 添加嵌套类
+    /// </summary>
+    /// <param name="configurator">关键字配置器</param>
+    /// <param name="configure">嵌套类选项配置委托</param>
+    /// <returns>类型选项</returns>
+    public static TypeOption NestedClass(
+        this KeywordOptionConfigurator<TypeOption> configurator,
+        Action<TypeOption> configure
+    )
+    {
+        configurator.Parent.AddChild<TypeOption, TypeOption>(to =>
+        {
+            configurator.Configure(keyword => to.WithKeyword(keyword));
+            configure(to);
+        });
+        return configurator.Parent;
+    }
+
+    #endregion
+
     #region Add member to type
 
     /// <summary>

--- a/EasyCodeBuilder/Csharp/OptionConfigurations/OptionConfigurations.cs
+++ b/EasyCodeBuilder/Csharp/OptionConfigurations/OptionConfigurations.cs
@@ -164,12 +164,11 @@ public static class KeywordConfiguratorExtensions
         Action<TypeOption> configure
     )
     {
-        configurator.Parent.AddChild<TypeOption, TypeOption>(to =>
+        return configurator.NestedClass(to =>
         {
-            configurator.Configure(keyword => to.WithKeyword(keyword));
             configure(to);
+            return to;
         });
-        return configurator.Parent;
     }
 
     #endregion

--- a/EasyCodeBuilder/Csharp/TypeOption.cs
+++ b/EasyCodeBuilder/Csharp/TypeOption.cs
@@ -112,6 +112,11 @@ public class TypeOption : CodeOption
     /// 静态修饰符配置器
     /// </summary>
     public KeywordOptionConfigurator<TypeOption> Static => KeywordConfigurator.Static;
+
+    /// <summary>
+    /// partial 修饰符配置器
+    /// </summary>
+    public KeywordOptionConfigurator<TypeOption> Partial => KeywordConfigurator.Partial;
 }
 
 /// <summary>


### PR DESCRIPTION
Closes #7. Add Partial property to TypeOption and NamespaceOption, add NestedClass extension on KeywordOptionConfigurator. All 64 tests pass.