### PR TITLE
Enable nested control flow blocks

### DIFF
--- a/EasyCodeBuilder.Test/Csharp/ControlFlowTests.cs
+++ b/EasyCodeBuilder.Test/Csharp/ControlFlowTests.cs
@@ -279,4 +279,198 @@ public class ControlFlowTests(ITestOutputHelper output)
         Assert.Contains("return \"Unknown\";", code);
         output.WriteLine(code);
     }
+
+    [Fact]
+    public void ForContainingSwitch_Issue11()
+    {
+        var code = new MethodOption()
+            .WithKeyword("public")
+            .WithName("Parse")
+            .WithReturnType("void")
+            .WithParameters("string[] args")
+            .For(f =>
+            {
+                f.WithInitializer("int i = 0")
+                 .WithCondition("i < args.Length")
+                 .WithIterator("i++");
+
+                f.Switch(s =>
+                {
+                    s.WithExpression("args[i]");
+                    s.Case(c =>
+                    {
+                        c.Value = "\"--x\"";
+                        c.AppendLine("x = int.Parse(args[++i]);");
+                        c.AppendLine("break;");
+                    });
+                    s.Default(d =>
+                    {
+                        d.AppendLine("break;");
+                    });
+                });
+            })
+            .Build();
+
+        var expected = """
+            public void Parse(string[] args)
+            {
+              for (int i = 0; i < args.Length; i++)
+              {
+                switch (args[i])
+                {
+                  case "--x":
+                  {
+                    x = int.Parse(args[++i]);
+                    break;
+                  }
+                  default:
+                  {
+                    break;
+                  }
+                }
+              }
+            }
+            """;
+
+        Assert.Equal(Norm(expected), Norm(code));
+        output.WriteLine(code);
+    }
+
+    [Fact]
+    public void DeepNesting_ForSwitchCaseIf()
+    {
+        var code = new MethodOption()
+            .WithKeyword("public")
+            .WithName("Deep")
+            .WithReturnType("void")
+            .For(f =>
+            {
+                f.WithInitializer("int i = 0")
+                 .WithCondition("i < items.Count")
+                 .WithIterator("i++");
+
+                f.Switch(s =>
+                {
+                    s.WithExpression("items[i].Type");
+                    s.Case(c =>
+                    {
+                        c.Value = "\"A\"";
+                        c.If(@if =>
+                        {
+                            @if.Condition = "items[i].Value > 0";
+                            @if.AppendLine("Process(items[i]);");
+                        });
+                    });
+                });
+            })
+            .Build();
+
+        Assert.Contains("for (int i = 0; i < items.Count; i++)", code);
+        Assert.Contains("switch (items[i].Type)", code);
+        Assert.Contains("case \"A\":", code);
+        Assert.Contains("if (items[i].Value > 0)", code);
+        Assert.Contains("Process(items[i]);", code);
+        output.WriteLine(code);
+    }
+
+    [Fact]
+    public void WhileContainingFor()
+    {
+        var code = new MethodOption()
+            .WithKeyword("public")
+            .WithName("Retry")
+            .WithReturnType("void")
+            .While(w =>
+            {
+                w.Condition = "retry";
+                w.For(f =>
+                {
+                    f.WithInitializer("int i = 0")
+                     .WithCondition("i < retries")
+                     .WithIterator("i++");
+                    f.AppendLine("Attempt(i);");
+                });
+            })
+            .Build();
+
+        Assert.Contains("while (retry)", code);
+        Assert.Contains("for (int i = 0; i < retries; i++)", code);
+        Assert.Contains("Attempt(i);", code);
+        output.WriteLine(code);
+    }
+
+    [Fact]
+    public void TryInsideFor()
+    {
+        var code = new MethodOption()
+            .WithKeyword("public")
+            .WithName("SafeIterate")
+            .WithReturnType("void")
+            .WithParameters("List<string> items")
+            .For(f =>
+            {
+                f.WithInitializer("int i = 0")
+                 .WithCondition("i < items.Count")
+                 .WithIterator("i++");
+
+                f.Try(t =>
+                {
+                    t.AppendLine("Process(items[i]);");
+                    t.Catch(c =>
+                    {
+                        c.WithExceptionType("Exception")
+                         .WithVariableName("ex");
+                        c.AppendLine("Log(ex);");
+                    });
+                });
+            })
+            .Build();
+
+        Assert.Contains("for (int i = 0; i < items.Count; i++)", code);
+        Assert.Contains("try", code);
+        Assert.Contains("Process(items[i]);", code);
+        Assert.Contains("catch (Exception ex)", code);
+        Assert.Contains("Log(ex);", code);
+        output.WriteLine(code);
+    }
+
+    [Fact]
+    public void IfElseIfElseInsideFor()
+    {
+        var code = new MethodOption()
+            .WithKeyword("public")
+            .WithName("Classify")
+            .WithReturnType("void")
+            .For(f =>
+            {
+                f.WithInitializer("int i = 0")
+                 .WithCondition("i < values.Length")
+                 .WithIterator("i++");
+
+                f.If(@if =>
+                {
+                    @if.Condition = "values[i] > 0";
+                    @if.AppendLine("Console.WriteLine(\"positive\");");
+                })
+                .ElseIf(elseIf =>
+                {
+                    elseIf.Condition = "values[i] < 0";
+                    elseIf.AppendLine("Console.WriteLine(\"negative\");");
+                })
+                .Else(@else =>
+                {
+                    @else.AppendLine("Console.WriteLine(\"zero\");");
+                });
+            })
+            .Build();
+
+        Assert.Contains("for (int i = 0; i < values.Length; i++)", code);
+        Assert.Contains("if (values[i] > 0)", code);
+        Assert.Contains("else if (values[i] < 0)", code);
+        Assert.Contains("else", code);
+        Assert.Contains("Console.WriteLine(\"positive\");", code);
+        Assert.Contains("Console.WriteLine(\"negative\");", code);
+        Assert.Contains("Console.WriteLine(\"zero\");", code);
+        output.WriteLine(code);
+    }
 }

--- a/EasyCodeBuilder/Csharp/Code.cs
+++ b/EasyCodeBuilder/Csharp/Code.cs
@@ -122,6 +122,87 @@ public static partial class Code
     }
 
     /// <summary>
+    /// Add an if statement to the code block.
+    /// </summary>
+    /// <param name="option">The code option.</param>
+    /// <param name="configure">Action to configure the if statement.</param>
+    /// <returns>The code option, for fluent chaining.</returns>
+    public static CodeOption If(this CodeOption option, Action<IfOption> configure)
+        => option.AddChild(configure);
+
+    /// <summary>
+    /// Add an else statement to the code block.
+    /// </summary>
+    /// <param name="option">The code option.</param>
+    /// <param name="configure">Action to configure the else statement.</param>
+    /// <returns>The code option, for fluent chaining.</returns>
+    public static CodeOption Else(this CodeOption option, Action<ElseOption> configure)
+        => option.AddChild(configure);
+
+    /// <summary>
+    /// Add an else-if statement to the code block.
+    /// </summary>
+    /// <param name="option">The code option.</param>
+    /// <param name="configure">Action to configure the else-if statement.</param>
+    /// <returns>The code option, for fluent chaining.</returns>
+    public static CodeOption ElseIf(this CodeOption option, Action<ElseIfOption> configure)
+        => option.AddChild(configure);
+
+    /// <summary>
+    /// Add a for loop to the code block.
+    /// </summary>
+    /// <param name="option">The code option.</param>
+    /// <param name="configure">Action to configure the for loop.</param>
+    /// <returns>The code option, for fluent chaining.</returns>
+    public static CodeOption For(this CodeOption option, Action<ForOption> configure)
+        => option.AddChild(configure);
+
+    /// <summary>
+    /// Add a while loop to the code block.
+    /// </summary>
+    /// <param name="option">The code option.</param>
+    /// <param name="configure">Action to configure the while loop.</param>
+    /// <returns>The code option, for fluent chaining.</returns>
+    public static CodeOption While(this CodeOption option, Action<WhileOption> configure)
+        => option.AddChild(configure);
+
+    /// <summary>
+    /// Add a do-while loop to the code block.
+    /// </summary>
+    /// <param name="option">The code option.</param>
+    /// <param name="configure">Action to configure the do-while loop.</param>
+    /// <returns>The code option, for fluent chaining.</returns>
+    public static CodeOption DoWhile(this CodeOption option, Action<DoWhileOption> configure)
+        => option.AddChild(configure);
+
+    /// <summary>
+    /// Add a foreach loop to the code block.
+    /// </summary>
+    /// <param name="option">The code option.</param>
+    /// <param name="configure">Action to configure the foreach loop.</param>
+    /// <returns>The code option, for fluent chaining.</returns>
+    public static CodeOption Foreach(this CodeOption option, Action<ForeachOption> configure)
+        => option.AddChild(configure);
+
+    /// <summary>
+    /// Add a switch statement to the code block.
+    /// </summary>
+    /// <param name="option">The code option.</param>
+    /// <param name="configure">Action to configure the switch statement.</param>
+    /// <returns>The code option, for fluent chaining.</returns>
+    public static CodeOption Switch(this CodeOption option, Action<SwitchOption> configure)
+        => option.AddChild(configure);
+
+    /// <summary>
+    /// Add a try-catch-finally statement to the code block.
+    /// </summary>
+    /// <param name="option">The code option.</param>
+    /// <param name="configure">Action to configure the try statement.</param>
+    /// <returns>The code option, for fluent chaining.</returns>
+    public static CodeOption Try(this CodeOption option, Action<TryOption> configure)
+        => option.AddChild(configure);
+
+    /// <summary>
     /// Add a namespace to the code.
     /// </summary>
     /// <param name="option">The root code option.</param>


### PR DESCRIPTION
## Summary

Fixes #11

Adds `If`, `Else`, `ElseIf`, `For`, `While`, `DoWhile`, `Foreach`, `Switch`, and `Try` extension methods on `CodeOption` (the base class) so control flow constructs can be nested inside any block.

### Before (broken)
```csharp
m.For(f =>
{
    f.Switch(s => { ... }); // ❌ Compile error: ForOption has no Switch method
});
```

### After (works)
```csharp
m.For(f =>
{
    f.Switch(s =>           // ✅ Now works via CodeOption extension
    {
        s.Case(c =>
        {
            c.If(i => { ... });  // ✅ Deep nesting works too
        });
    });
});
```

## Changes

- **`Code.cs`**: Added 9 control flow extension methods on `CodeOption` following the same `AddChild` pattern as existing methods
- **`ControlFlowTests.cs`**: Added 5 new tests covering nesting scenarios:
  - `ForContainingSwitch_Issue11` — the exact example from the issue
  - `DeepNesting_ForSwitchCaseIf` — 3 levels deep
  - `WhileContainingFor` — loop nesting
  - `TryInsideFor` — exception handling inside a loop
  - `IfElseIfElseInsideFor` — conditional branching inside a loop

## Backward Compatibility

The existing `MethodOptionExtensions` methods are **not modified**. C# overload resolution prefers the more-specific `MethodOption` overload when called on a `MethodOption`, so all existing code continues to work unchanged.

## Test Results

All 81 tests pass (76 existing + 5 new).

🤞 Generated with [Claude Code](https://claude.com/claude-code)